### PR TITLE
Http error interceptor with non-implemented methods

### DIFF
--- a/src/app/core/interceptors/http-error.interceptor.spec.ts
+++ b/src/app/core/interceptors/http-error.interceptor.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { HttpErrorInterceptor } from './http-error.interceptor';
+
+describe('HttpErrorInterceptor', () => {
+  beforeEach(() => TestBed.configureTestingModule({
+    providers: [
+      HttpErrorInterceptor
+      ]
+  }));
+
+  it('should be created', () => {
+    const interceptor: HttpErrorInterceptor = TestBed.inject(HttpErrorInterceptor);
+    expect(interceptor).toBeTruthy();
+  });
+});

--- a/src/app/core/interceptors/http-error.interceptor.ts
+++ b/src/app/core/interceptors/http-error.interceptor.ts
@@ -1,0 +1,120 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpErrorResponse,
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+} from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+//TODO: It's necessary to inject a service (or any other mechanism) that could display error messages on UI.
+
+//TODO: It's necessary to add a logic for all methods that are not completed, based on system requirements.
+
+@Injectable()
+export class HttpErrorInterceptor implements HttpInterceptor {
+  constructor() {}
+
+  /**
+   * The interceptor method.
+   *
+   * @param req - Current request.
+   * @param next - HttpHandler.
+   */
+  public intercept(
+    req: HttpRequest<any>,
+    next: HttpHandler
+  ): Observable<HttpEvent<any>> {
+    return next.handle(req).pipe(
+      catchError((error: HttpErrorResponse) => {
+        const errorStatus = error.status;
+        // classify by code
+        const isClientError = errorStatus % 400 <= 99;
+        const isServerError = errorStatus % 500 <= 99;
+
+        if (isClientError) {
+          this.handleClientError(error);
+        } else if (isServerError) {
+          this.handleServerError(error);
+        } else {
+          this.defaultErrorHandler(error);
+        }
+
+        return throwError(error.message);
+      })
+    );
+  }
+
+  /**
+   * Will simply load notify.
+   *
+   * @param error - Error ocurred.
+   */
+  private defaultErrorHandler(error: HttpErrorResponse) {
+    throw new Error('Method not implemented.');
+  }
+
+  /**
+   * Handle all server errors (5xx).
+   *
+   * @param error - Error ocurred.
+   */
+  private handleServerError(error: HttpErrorResponse) {
+    throw new Error('Method not implemented.');
+  }
+
+  /**
+   * Handle all client errors (4xx).
+   *
+   * @param error - Error ocurred.
+   */
+  private handleClientError(error: HttpErrorResponse) {
+    const errorStatus = error.status;
+    switch (errorStatus) {
+      case 400:
+        this.handleValidationError(error);
+        break;
+      case 401:
+        this.handleAuthError(error);
+        break;
+      case 403:
+        this.handleUnauthorizedError(error);
+        break;
+      case 422:
+        this.handleValidationError(error);
+        break;
+      default:
+        this.defaultErrorHandler(error);
+        break;
+    }
+  }
+
+  /**
+   * Authorization error.
+   *
+   * @param error - Error ocurred.
+   */
+  private handleAuthError(error: HttpErrorResponse) {
+    throw new Error('Method not implemented.');
+  }
+
+  /**
+   * Not authorized.
+   *
+   * @param error Error that ocurred.
+   */
+  private handleUnauthorizedError(error: HttpErrorResponse) {
+    throw new Error('Method not implemented.');
+  }
+
+  /**
+   * Form Validation error method, here we'll iterate through each validation message in response
+   *
+   * @param error - Error ocurred.
+   */
+  private handleValidationError(error: HttpErrorResponse) {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/src/app/core/interceptors/http-error.interceptor.ts
+++ b/src/app/core/interceptors/http-error.interceptor.ts
@@ -73,9 +73,9 @@ export class HttpErrorInterceptor implements HttpInterceptor {
   private handleClientError(error: HttpErrorResponse) {
     const errorStatus = error.status;
     switch (errorStatus) {
-      case 400:
-        this.handleValidationError(error);
-        break;
+      // case 400:
+      //   this.handleValidationError(error);
+      //   break;
       case 401:
         this.handleAuthError(error);
         break;

--- a/src/app/core/interceptors/index.ts
+++ b/src/app/core/interceptors/index.ts
@@ -1,0 +1,1 @@
+export * from './http-error.interceptor';


### PR DESCRIPTION
The presented error handler interceptor is created by strongly relaying on [HTTP error codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status).
There are few TODOs inside the error handler, that should be handled.